### PR TITLE
Add .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+indent_size = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
Add `.editorconfig` to set the indent style to tabs with a width of 4 columns. This should match your current style being used, and will fix the indents in files when viewing on GitHub or in an editor that supports reading an `.editorconfig` file.

I also set `charset`, `end_of_line`, and `trim_trailing_whitespace` to reasonable defaults.