### PR TITLE
fix FntLoad to non-zero y locations for debug font

### DIFF
--- a/libpsn00b/psxetc/font.c
+++ b/libpsn00b/psxetc/font.c
@@ -19,7 +19,7 @@ void FntLoad(int x, int y) {
 	pos.x = x;
 	pos.y = y;
 	
-	_font_tpage = getTPage( 0, 0, pos.x, 0 ) | 0x200;
+	_font_tpage = getTPage( 0, 0, pos.x, pos.y ) | 0x200;
 	
 	LoadImage( &pos, tim.paddr );
 	DrawSync(0);


### PR DESCRIPTION
FntSort wasn't rendering when using FntLoad to non-zero y locations (e.g. x=960, y=256); this fixed it for me