### PR TITLE
Fix setDrawMask macro

### DIFF
--- a/libpsn00b/include/psxgpu.h
+++ b/libpsn00b/include/psxgpu.h
@@ -140,7 +140,7 @@
 	
 /* ORIGINAl CODE */
 #define setDrawMask( p, sb, mt ) \
-	setlen( p, 1 ), p->code[0] = sb|(mt<<1), \
+	setlen( p, 1 ), (p)->code[0] = sb|(mt<<1), \
 	setcode( p, 0xe6 )
 	
 	


### PR DESCRIPTION
Missing parenthesis caused compilation error when passing a reference to DR_MASK