### PR TITLE
CDGetToc: Fix getting min/sec timestamps

### DIFF
--- a/libpsn00b/psxcd/psxcd.c
+++ b/libpsn00b/psxcd/psxcd.c
@@ -171,7 +171,8 @@ int CdGetToc(CdlLOC *toc)
 	for(i=0; i<tracks; i++)
 	{
 		int t = itob(1+i);
-		if( !CdControl(CdlGetTD, (u_char*)&t, (u_char*)&toc[i]) )
+		struct { u_char status, toc_min, toc_sec; } res;
+		if( !CdControl(CdlGetTD, (u_char*)&t, (u_char*)&res) )
 		{
 			return 0;
 		}
@@ -179,6 +180,8 @@ int CdGetToc(CdlLOC *toc)
 		{
 			return 0;
 		}
+		toc[i].minute = res.toc_min;
+		toc[i].second = res.toc_sec;
 		toc[i].sector = 0;
 		toc[i].track = 1+i;
 	}


### PR DESCRIPTION
The `CdlGetTD` function does not return a `CdlLOC` value, but instead a struct:

```
struct {
   u_char status;
   u_char toc_min;
   u_char toc_sec;
};
```

The old code writes status into `minute`, toc_min to `second`, toc_sec into `sector` and then overwrites sector with zero.

This patch fixes it by storing the result in a temporary variable and then copying the right fields into the `CdlLOC` struct.

See also: [CdlGetTD in PCSX-ReARMed's cdrom.c](https://github.com/notaz/pcsx_rearmed/blob/0d9eed84e1484897dc1673bf534a2c1e7ec3ee54/libpcsxcore/cdrom.c#L800)