### PR TITLE
libc: Add abs() and labs() functions

### DIFF
--- a/libpsn00b/include/stdlib.h
+++ b/libpsn00b/include/stdlib.h
@@ -49,6 +49,7 @@ int rand();
 void srand(unsigned long seed);
 
 int abs(int j);
+long labs(long i);
 long long strtoll(const char *nptr, char **endptr, int base);
 long strtol(const char *nptr, char **endptr, int base);
 long double strtold(const char *nptr, char **endptr);

--- a/libpsn00b/libc/abs.c
+++ b/libpsn00b/libc/abs.c
@@ -1,0 +1,7 @@
+int abs(int i) {
+	return (i < 0) ? (-i) : i;
+}
+
+long labs(long i) {
+	return (i < 0) ? (-i) : i;
+}


### PR DESCRIPTION
The .c file is picked up by `CFILES          = $(notdir $(wildcard ./*.c))` in the `makefile`, so no build system changes needed.