### PR TITLE
Removed redundant CC/CXX/etc definitions

### DIFF
--- a/examples/gte/makefile
+++ b/examples/gte/makefile
@@ -8,8 +8,8 @@ AFILES		= $(notdir $(wildcard *.s))
 
 OFILES		= $(addprefix build/,$(CFILES:.c=.o) $(CPPFILES:.cpp=.o) $(AFILES:.s=.o))
 
-INCLUDE	 	+= 
-LIBDIRS		+= 
+INCLUDE	 	+=
+LIBDIRS		+=
 
 LIBS		= -lc -lpsxetc -lpsxgpu -lpsxgte -lpsxspu -lpsxapi -lc
 
@@ -18,22 +18,17 @@ CPPFLAGS	= $(CFLAGS) -fno-exceptions
 AFLAGS		= -g -msoft-float
 LDFLAGS		= -g -Ttext=0x80010000 -gc-sections -T $(GCC_BASE)/mipsel-unknown-elf/lib/ldscripts/elf32elmip.x
 
-CC			= $(PREFIX)gcc
-CXX			= $(PREFIX)g++
-AS			= $(PREFIX)as
-LD			= $(PREFIX)ld
-
 all: $(OFILES)
 	$(LD) $(LDFLAGS) $(LIBDIRS) $(OFILES) $(LIBS) -o $(TARGET)
-	elf2x -q $(TARGET)
-	
+	../../tools/util/elf2x -q $(TARGET)
+
 build/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
-	$(CC) $(AFLAGS) $(INCLUDE) -c $< -o $@
-	
+	$(AS) $(AFLAGS) $(INCLUDE) -c $< -o $@
+
 clean:
 	rm -rf build $(TARGET) $(TARGET:.elf=.exe)

--- a/examples/n00bdemo/makefile
+++ b/examples/n00bdemo/makefile
@@ -17,29 +17,29 @@ CPPFLAGS	= $(CFLAGS) -fno-exceptions
 AFLAGS		= -g -msoft-float
 LDFLAGS		= -g -Ttext=0x80010000 -gc-sections -T $(GCC_BASE)/mipsel-unknown-elf/lib/ldscripts/elf32elmip.x
 
-CC			= $(PREFIX)gcc
-CXX			= $(PREFIX)g++
-AS			= $(PREFIX)as
-LD			= $(PREFIX)ld
+CC			= $(GCC_BASE)/bin/$(PREFIX)gcc
+CXX			= $(GCC_BASE)/bin/$(PREFIX)g++
+AS			= $(GCC_BASE)/bin/$(PREFIX)as
+LD			= $(GCC_BASE)/bin/$(PREFIX)ld
 
 all: resources $(OFILES)
 	$(LD) $(LDFLAGS) $(LIBDIRS) $(OFILES) $(LIBS) -o $(TARGET)
-	elf2x -q $(TARGET)
-	
+	../../tools/util/elf2x -q $(TARGET)
+
 build/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
-	$(CC) $(AFLAGS) $(INCLUDE) -c $< -o $@
-	
+	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@
+
 resources:
-	lzpack data.xml
+	../../tools/lzpack/lzpack data.xml
 	touch data.s
-	
+
 iso:
 	mkpsxiso -y -q -o demo.iso iso.xml
-	
+
 clean:
 	rm -rf build *.lzp *.qlp $(TARGET) $(TARGET:.elf=.exe) $(TARGET:.elf=.iso)

--- a/examples/sdk-common.mk
+++ b/examples/sdk-common.mk
@@ -12,7 +12,7 @@ LIBDIRS		= -L../../libpsn00b
 
 ifndef GCC_VERSION
 
-GCC_VERSION	= 7.4.0
+GCC_VERSION	= 8.2.0
 
 endif
 
@@ -27,6 +27,11 @@ else						# For Linux/BSDs
 GCC_BASE	= /usr/local/mipsel-unknown-elf
 
 endif
+
+CC			= $(GCC_BASE)/bin/$(PREFIX)gcc
+CXX			= $(GCC_BASE)/bin/$(PREFIX)g++
+AS			= $(GCC_BASE)/bin/$(PREFIX)as
+LD			= $(GCC_BASE)/bin/$(PREFIX)ld
 
 endif
 

--- a/libpsn00b/common.mk
+++ b/libpsn00b/common.mk
@@ -4,7 +4,7 @@
 # GCC version
 ifndef GCC_VERSION
 
-GCC_VERSION	= 7.4.0
+GCC_VERSION	= 8.2.0
 
 endif
 
@@ -26,6 +26,12 @@ endif
 
 # Toolchain prefix
 PREFIX		= mipsel-unknown-elf-
+
+CC		= $(GCC_BASE)/bin/$(PREFIX)gcc
+CXX		= $(GCC_BASE)/bin/$(PREFIX)g++
+AS		= $(GCC_BASE)/bin/$(PREFIX)as
+AR		= $(GCC_BASE)/bin/$(PREFIX)ar
+RANLIB	= $(GCC_BASE)/bin/$(PREFIX)ranlib
 
 # Include directories
 INCLUDE	 	= -I../include

--- a/libpsn00b/libc/makefile
+++ b/libpsn00b/libc/makefile
@@ -12,13 +12,8 @@ AFILES		= $(notdir $(wildcard ./*.s))
 OFILES		= $(addprefix build/,$(CFILES:.c=.o) $(CXXFILES:.cxx=.o) $(AFILES:.s=.o))
 
 CFLAGS	= -g -O2 -msoft-float -fno-builtin -fdata-sections -ffunction-sections -Wa,--strip-local-absolute
-AFLAGS	= -g -msoft-float -Wa,-strip-local-absolute
+AFLAGS	= -g -msoft-float --strip-local-absolute
 
-CC		= $(PREFIX)gcc
-CXX		= $(PREFIX)g++
-AS		= $(PREFIX)as
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
 
 all: $(TARGET)
 
@@ -34,10 +29,10 @@ build/%.o: %.c
 build/%.o: %.cxx
 	@mkdir -p $(dir $@)
 	$(CXX) $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
-	$(CC) $(AFLAGS) $(INCLUDE) -c $< -o $@
+	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@
 
 clean:
 	rm -Rf build $(TARGET)

--- a/libpsn00b/lzp/makefile
+++ b/libpsn00b/lzp/makefile
@@ -7,16 +7,12 @@ OFILES	= $(addprefix build/,$(CFILES:.c=.o))
 
 CFLAGS	= -g -O2 -msoft-float -fno-builtin -nostdlib -fdata-sections -ffunction-sections -Wa,--strip-local-absolute
 
-CC		= $(PREFIX)gcc
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
-
 all: $(TARGET)
 
 $(TARGET): $(OFILES)
 	$(AR) cr $(TARGET) $(OFILES)
 	$(RANLIB) $(TARGET)
-	
+
 build/%.o: %.c
 	@mkdir -p build
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@

--- a/libpsn00b/psxapi/makefile
+++ b/libpsn00b/psxapi/makefile
@@ -11,22 +11,17 @@ SOURCES	= stdio fs sys
 AFILES	= $(foreach dir,$(SOURCES),$(wildcard $(dir)/*.s))
 OFILES	= $(addprefix build/,$(AFILES:.s=.o))
 
-AFLAGS	= -g -msoft-float -Wa,--strip-local-absolute
-
-CC		= $(PREFIX)gcc
-AS		= $(PREFIX)as
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
+AFLAGS	= -g -msoft-float -strip-local-absolute
 
 all: $(TARGET)
-	
+
 $(TARGET): $(OFILES)
 	$(AR) cr $(TARGET) $(OFILES)
 	$(RANLIB) $(TARGET)
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
-	$(CC) $(AFLAGS) $(INCLUDE) -c $< -o $@
+	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@
 
 clean:
 	rm -Rf build $(TARGET)

--- a/libpsn00b/psxcd/makefile
+++ b/libpsn00b/psxcd/makefile
@@ -12,13 +12,8 @@ OFILES	= $(addprefix build/,$(CFILES:.c=.o) $(AFILES:.s=.o))
 
 INCLUDE = -I../include
 
-CFLAGS	= -g -msoft-float -fno-builtin -fdata-sections -ffunction-sections -Wa,--strip-local-absolute 
-AFLAGS	= -g -msoft-float -Wa,--strip-local-absolute
-
-CC		= $(PREFIX)gcc
-AS		= $(PREFIX)as
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
+CFLAGS	= -g -msoft-float -fno-builtin -fdata-sections -ffunction-sections -Wa,--strip-local-absolute
+AFLAGS	= -g -msoft-float -strip-local-absolute
 
 all: $(TARGET)
 
@@ -29,10 +24,10 @@ $(TARGET): $(OFILES)
 build/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) -O2 $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
-	$(CC) $(AFLAGS) $(INCLUDE) -c $< -o $@
+	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@
 
 clean:
 	rm -Rf build $(TARGET)

--- a/libpsn00b/psxetc/makefile
+++ b/libpsn00b/psxetc/makefile
@@ -13,11 +13,6 @@ OFILES	= $(addprefix build/,$(CFILES:.c=.o) $(AFILES:.s=.o))
 CFLAGS	= -g -O2 -msoft-float -fno-builtin -nostdlib -fdata-sections -ffunction-sections -Wa,--strip-local-absolute
 AFLAGS	= -g -msoft-float -strip-local-absolute
 
-CC		= $(PREFIX)gcc
-AS		= $(PREFIX)as
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
-
 all: $(TARGET)
 
 $(TARGET): $(OFILES)
@@ -27,7 +22,7 @@ $(TARGET): $(OFILES)
 build/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
 	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@

--- a/libpsn00b/psxgpu/makefile
+++ b/libpsn00b/psxgpu/makefile
@@ -11,12 +11,7 @@ AFILES	= $(notdir $(wildcard ./*.s))
 OFILES	= $(addprefix build/,$(CFILES:.c=.o) $(AFILES:.s=.o))
 
 CFLAGS	= -g -O2 -msoft-float -fno-builtin -fdata-sections -ffunction-sections -Wa,--strip-local-absolute
-AFLAGS	= -g -msoft-float -Wa,--strip-local-absolute
-
-CC		= $(PREFIX)gcc
-AS		= $(PREFIX)as
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
+AFLAGS	= -g -msoft-float -strip-local-absolute
 
 all: $(TARGET)
 
@@ -27,10 +22,10 @@ $(TARGET): $(OFILES)
 build/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
-	$(CC) $(AFLAGS) $(INCLUDE) -c $< -o $@
+	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@
 
 clean:
 	rm -Rf build $(TARGET)

--- a/libpsn00b/psxgte/makefile
+++ b/libpsn00b/psxgte/makefile
@@ -13,11 +13,6 @@ OFILES	= $(addprefix build/,$(CFILES:.c=.o) $(AFILES:.s=.o))
 CFLAGS	= -g -O2 -msoft-float -fno-builtin -fdata-sections -ffunction-sections -Wa,--strip-local-absolute
 AFLAGS	= -g -msoft-float -strip-local-absolute
 
-CC		= $(PREFIX)gcc
-AS		= $(PREFIX)as
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
-
 all: $(TARGET)
 
 $(TARGET): $(OFILES)
@@ -27,7 +22,7 @@ $(TARGET): $(OFILES)
 build/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
 	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@

--- a/libpsn00b/psxsio/makefile
+++ b/libpsn00b/psxsio/makefile
@@ -11,12 +11,7 @@ AFILES	= $(notdir $(wildcard ./*.s))
 OFILES	= $(addprefix build/,$(CFILES:.c=.o) $(AFILES:.s=.o))
 
 CFLAGS	= -g -O2 -msoft-float -fno-builtin -fdata-sections -ffunction-sections -Wa,--strip-local-absolute
-AFLAGS	= -g -msoft-float -Wa,--strip-local-absolute
-
-CC		= $(PREFIX)gcc
-AS		= $(PREFIX)as
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
+AFLAGS	= -g -msoft-float -strip-local-absolute
 
 all: $(TARGET)
 
@@ -27,10 +22,10 @@ $(TARGET): $(OFILES)
 build/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
-	$(CC) $(AFLAGS) $(INCLUDE) -c $< -o $@
+	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@
 
 clean:
 	rm -Rf build $(TARGET)

--- a/libpsn00b/psxspu/makefile
+++ b/libpsn00b/psxspu/makefile
@@ -9,11 +9,6 @@ OFILES	= $(addprefix build/,$(CFILES:.c=.o) $(AFILES:.s=.o))
 CFLAGS	= -g -O2 -msoft-float -fdata-sections -ffunction-sections -Wa,--strip-local-absolute
 AFLAGS	= -g -msoft-float -strip-local-absolute
 
-CC		= $(PREFIX)gcc
-AS		= $(PREFIX)as
-AR		= $(PREFIX)ar
-RANLIB	= $(PREFIX)ranlib
-
 all: $(TARGET)
 
 $(TARGET): $(OFILES)
@@ -23,7 +18,7 @@ $(TARGET): $(OFILES)
 build/%.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
-	
+
 build/%.o: %.s
 	@mkdir -p $(dir $@)
 	$(AS) $(AFLAGS) $(INCLUDE) $< -o $@


### PR DESCRIPTION
.s files are now compiled via as instead of gcc. Otherwise, a missing
header file error (gcc does not include "hwregs_a.h" for some reason when compiling assembly files, even if -I flag is properly given) would occur.
GCC version has been changed to 8.2.0 (both gte and n00bdemo have been tested with no issues whatsoever). There's no problem sticking to 7.4.0 if needed, though.
Many examples are still implementing their own CC/CXX/AS/etc definitions, so it would be a good idea to change that on another commit.