### PR TITLE
Account for forward-looped memmove

### DIFF
--- a/libpsn00b/libc/memmove.s
+++ b/libpsn00b/libc/memmove.s
@@ -10,20 +10,33 @@
 .type memmove, @function
 memmove:
 	move	$v0, $a0
+	sltu	$v1, $a0, $a1
+	blez	$v1, .Linit_backward
+.Lloop_forward:
+	blez	$a2, .Lexit
+	addi	$a2, -1
+	lbu		$v1, 0($a1)
+	addiu	$a1, 1
+	sb		$v1, 0($a0)
+	addiu	$a0, 1
+	b		.Lloop_forward
+	nop
+.Linit_backward:
 	addu	$a0, $a2
 	addu	$a1, $a2
 	addiu	$a0, -1
 	addiu	$a1, -1
-.Lloop:
+	b		.Lloop_backward
+	nop
+.Lloop_backward:
 	blez	$a2, .Lexit
 	addi	$a2, -1
 	lbu		$v1, 0($a1)
 	addiu	$a1, -1
 	sb		$v1, 0($a0)
 	addiu	$a0, -1
-	b		.Lloop
+	b		.Lloop_backward
 	nop
 .Lexit:
 	jr		$ra
 	nop
-	


### PR DESCRIPTION
Currently, memmove will only overlap memory correctly if the destination address is greater than the source address.  This fixes the problem and allows bi-directional overlapping for memmove.

I don't know if this is the best way to do this since I barely know assembly, but it works pretty well.

This is based on the C implementation here: https://clc-wiki.net/wiki/C_standard_library:string.h:memmove