### PR TITLE
correct setting of address in AddPrim

### DIFF
--- a/libpsn00b/psxgpu/addprim.s
+++ b/libpsn00b/psxgpu/addprim.s
@@ -10,6 +10,10 @@ AddPrim:
 
 	lw		$v0, 0($a0)				# Load OT entry
 	lw		$v1, 0($a1)				# Set packet length value (in words)
+	
+	lui 	$at, 0xff00
+	and		$v1, $at				# Clear address in primitive, keep length
+	
 	lui		$at, 0x00ff
 	or		$at, 0xffff
 	and		$v0, $at				# Mask off the upper 8 bits of OT entry


### PR DESCRIPTION
Fixes addresses in primitives being logically ORed with the new value, instead of being set to the new value.