### PR TITLE
Add C11 error checking to vsnprintf()

### DIFF
--- a/libpsn00b/libc/vsprintf.c
+++ b/libpsn00b/libc/vsprintf.c
@@ -391,6 +391,9 @@ int vsnprintf(char *string, unsigned int size, const char *fmt, va_list ap)
 	int zero_flag_imp = 0;
 	int pad_quantity = 0;
 	int last;
+
+	// C11: required to check these cases and return error if detected
+	if (string == NULL || fmt == NULL || size == 0) { return -1; }
 	
 	l = strlen(fmt);
 	


### PR DESCRIPTION
C11 specifies that `vsnprintf()` is to check for the following conditions:
- output buffer or format string are null pointers
- buffer size is zero

C11 also specifies "constraint handler functions" that may be set, but that's far more involved, and having at least some error-handling for bad arguments like these is probably quite useful.

Source: https://en.cppreference.com/w/c/io/vfprintf#:~:text=5%2D8),constraint%20handler%20function%3A

I know the C library provided here doesn't specify C99 or C11 (although the former is implied due to the presence of functions like `vsnprintf()` and friends), but this seems like a useful and important error case to check.

Let me know what you think