### PR TITLE
Initial implementation of stdlib div() in MIPS assembly

### DIFF
--- a/libpsn00b/include/stdlib.h
+++ b/libpsn00b/include/stdlib.h
@@ -1,6 +1,7 @@
 /*
  * PSn00bSDK standard library
  * (C) 2019-2022 PSXSDK authors, Lameguy64, spicyjpeg - MPL licensed
+ * (C) 2023 saxbophone (minor additions) - MPL licensed
  */
 
 #ifndef __STDLIB_H
@@ -22,6 +23,11 @@ typedef struct _HeapUsage {
 	size_t alloc_max;	// Maximum amount of memory ever allocated
 } HeapUsage;
 
+typedef struct {
+    int quot; // quotient result of integer division
+    int rem;  // remainder
+} div_t;
+
 /* API */
 
 #ifdef __cplusplus
@@ -38,6 +44,7 @@ void srand(int seed);
 
 int abs(int j);
 long labs(long i);
+div_t div(int x, int y);
 
 long strtol(const char *nptr, char **endptr, int base);
 long long strtoll(const char *nptr, char **endptr, int base);

--- a/libpsn00b/libc/div.c
+++ b/libpsn00b/libc/div.c
@@ -1,0 +1,27 @@
+/*
+ * PSn00bSDK stdlib div() implementation
+ * (C) 2023 saxbophone - MPL licensed
+ */
+
+#include <stdlib.h>
+
+div_t div(int x, int y) {
+    div_t result = {0};
+    /*
+     * the MIPS R3000 DIV instruction calculates both quotient and remainder in
+     * one go, so we take advantage of it using inline assembly, for speed.
+     */
+    /*
+     * volatile might not be needed here
+     * looks like optimiser is smart enough to tell that mflo/hi are not constant
+     */
+    __asm__ /*volatile*/ (
+        "div $0, %2, %3;" // divide x by y (dst is set to $0 to request manual division mode)
+                          // NOTE: on the R3000, division by zero doesn't trap in this mode
+        "mflo %0;"        // copy quotient out
+        "mfhi %1;"        // copy remainder out
+      : "=r" (result.quot), "=r" (result.rem)
+      : "r" (x), "r" (y)
+    );
+    return result;
+}


### PR DESCRIPTION
Not tested building with the SDK yet, but initial tests of just this function compiling to MIPS binary using an online compiler suggests it works correctly: https://godbolt.org/z/GqE5fxz5b

I will test with the SDK on my other machine when I get a chance and send any revisions before marking ready for review.