### PR TITLE
`realloc` size in `BlockHeader` incorrect causing `_find_fit` negative sizes

### DIFF
--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -85,10 +85,8 @@ static BlockHeader *_find_fit(BlockHeader *head, size_t size) {
 	for (; prev; prev = prev->next) {
 		if (prev->next) {
 			uintptr_t next_bot = (uintptr_t) prev->next;
-			printf("[FindFit] Bottom of next block: %p\n", (void*)next_bot);
 			next_bot          -= (uintptr_t) prev->ptr + prev->size;
-			printf("[FindFit] Offset to free block: %p\n", (void*)prev->ptr + prev->size);
-			printf("[FindFit] Size of free block: %p\n", next_bot);
+
 			if (next_bot >= size)
 				return prev;
 		}

--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -85,8 +85,10 @@ static BlockHeader *_find_fit(BlockHeader *head, size_t size) {
 	for (; prev; prev = prev->next) {
 		if (prev->next) {
 			uintptr_t next_bot = (uintptr_t) prev->next;
+			printf("[FindFit] Bottom of next block: %p\n", (void*)next_bot);
 			next_bot          -= (uintptr_t) prev->ptr + prev->size;
-
+			printf("[FindFit] Offset to free block: %p\n", (void*)prev->ptr + prev->size);
+			printf("[FindFit] Size of free block: %p\n", next_bot);
 			if (next_bot >= size)
 				return prev;
 		}

--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -199,7 +199,7 @@ __attribute__((weak)) void *realloc(void *ptr, size_t size) {
 	// New memory block shorter?
 	if (prev->size >= _size) {
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 
 		if (!prev->next)
 			sbrk((ptr - sbrk(0)) + _size);
@@ -214,14 +214,14 @@ __attribute__((weak)) void *realloc(void *ptr, size_t size) {
 			return 0;
 
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 		return ptr;
 	}
 
 	// Do we have free memory after it?
 	if (((prev->next)->ptr - ptr) > _size) {
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 		return ptr;
 	}
 


### PR DESCRIPTION
The `BlockHeader.size` field is incorrectly set, still including the `sizeof(BlockHeader)` overhead included in the aligned value used as the size of the allocated block.

This causes the `_find_fit` function to improperly calculate the size of the free block for the currently inspected block. More details in the associated issue I raised here: https://github.com/Lameguy64/PSn00bSDK/issues/80