### PR TITLE
Add `enum` and/or defines for flag/mode variables in structures and functions

### DIFF
--- a/libpsn00b/include/psxgpu.h
+++ b/libpsn00b/include/psxgpu.h
@@ -540,6 +540,11 @@ typedef struct {
 	uint8_t		_reserved;
 } DISPENV;
 
+// Use 16-bit colors (isrgb24)
+#define DISPENV_COLOR_MODE_16_BIT 0
+// Use 24-bit colors (isrgb24)
+#define DISPENV_COLOR_MODE_24_BIT 1
+
 typedef struct {
 	RECT		clip;		// Drawing area
 	int16_t		ofs[2];		// GPU draw offset (relative to draw area)
@@ -551,6 +556,21 @@ typedef struct {
 	uint8_t		r0, g0, b0;	// Draw area clear color (if isbg iz nonzero)
 	DR_ENV		dr_env;		// GPU primitive cache area (used internally)
 } DRAWENV;
+
+// Disable dither processing (dtd)
+#define DRAWENV_DITHER_DISABLED 0
+// Enable dither processing (dtd)
+#define DRAWENV_DITHER_ENABLED 1
+
+// Disable draw to display (dfe)
+#define DRAWENV_DISPLAY_DISABLED 0
+// Enable draw to display (dfe)
+#define DRAWENV_DISPLAY_ENABLED 1
+
+// Disable draw area clear on env set (isbg)
+#define DRAWENV_CLEAR_ON_SET_DISABLED 0
+// Enable draw area clear on env set (isbg)
+#define DRAWENV_CLEAR_ON_SET_ENABLED 1
 
 typedef struct {
 	uint32_t	mode;

--- a/libpsn00b/include/psxgpu.h
+++ b/libpsn00b/include/psxgpu.h
@@ -594,7 +594,16 @@ typedef struct {
 extern "C" {
 #endif
 
-void ResetGraph(int mode);
+typedef enum {
+	// Resets GPU including video mode and sets displaymask to 0
+	RESET_GRAPH_ALL_VIDEO_MODE_DISPLAY_MASK = 0,
+	// Cancels any outgoing DMA requests and resets the GPU command buffer
+	RESET_GRAPH_DMA_IRQ_COMMAND_BUFFER = 1,
+	// Resets the GPU command buffer
+	RESET_GRAPH_COMMAND_BUFFER = 2
+} ResetGraphMode;
+
+void ResetGraph(ResetGraphMode mode);
 
 GPU_VideoMode GetVideoMode(void);
 void SetVideoMode(GPU_VideoMode mode);

--- a/libpsn00b/include/smd/smd.h
+++ b/libpsn00b/include/smd/smd.h
@@ -43,29 +43,36 @@ typedef struct {
 	uint8_t len;
 } SMD_PRI_TYPE;
 
+typedef enum: uint8_t {
+	SMD_KIND_LINE = 0,
+	SMD_KIND_TRIANGLE = 1,
+	SMD_KIND_QUAD = 2,
+} SMD_KIND;
 
-#define SMD_PRI_TYPE_LINE 0
-#define SMD_PRI_TYPE_TRIANGLE 1
-#define SMD_PRI_TYPE_QUAD 2
+typedef enum: uint8_t {
+	// No shading (no normals)
+	SMD_LIGHTING_NONE = 0,
+	// Flat shading (1 normal)
+	SMD_LIGHTING_FLAT = 1,
+	// Smooth shading (3 normals)
+	SMD_LIGHTING_SMOOTH = 2
+} SMD_LIGHTING;
 
-// No shading (no normals)
-#define SMD_PRI_TYPE_LIGHTING_NONE 0
-// Flat shading (1 normal)
-#define SMD_PRI_TYPE_LIGHTING_FLAT 1
-// Smooth shading (3 normals per vectex)
-#define SMD_PRI_TYPE_LIGHTING_SMOOTH 2
+typedef enum: uint8_t {
+	SMD_COLORING_SOLID = 0,
+	SMD_COLORING_GOURAUD = 1
+} SMD_COLORING;
 
-#define SMD_PRI_TYPE_COLORING_SOLID 0
-#define SMD_PRI_TYPE_COLORING_GOURAUD 1
-
-// 50% Background + 50% Foreground (50% alpha)
-#define SMD_PRI_TYPE_BLEND_50_ALPHA 0
-// 100% background + 100% foreground (additive)
-#define SMD_PRI_TYPE_BLEND_ADD 1
-// 100% background - 100% foreground (subtractive)
-#define SMD_PRI_TYPE_BLEND_SUB 2
-// 100% background - 25% foreground (subtract 25%)
-#define SMD_PRI_TYPE_BLEND_25_SUB 3
+typedef enum: uint8_t {
+	// 50% background + 50% foreground (50% alpha)
+	SMD_BLEND_ALPHA_50 = 0,
+	// 100% background + 100% foreground (additive)
+	SMD_BLEND_ADDITIVE = 1,
+	// 100% background - 100% foreground (subtractive)
+	SMD_BLEND_SUBTRACT = 2,
+	// 100% background - 25% foreground (subtract 25%)
+	SMD_BLEND_SUBTRACT_25 = 3
+} SMD_BLEND;
 
 typedef struct {
 	SMD_PRI_TYPE prim_id;

--- a/libpsn00b/include/smd/smd.h
+++ b/libpsn00b/include/smd/smd.h
@@ -43,20 +43,28 @@ typedef struct {
 	uint8_t len;
 } SMD_PRI_TYPE;
 
+
 #define SMD_PRI_TYPE_LINE 0
 #define SMD_PRI_TYPE_TRIANGLE 1
 #define SMD_PRI_TYPE_QUAD 2
 
-#define SMD_PRI_TYPE_LIGHTING_NONE 0 // No shading (no normals)
-#define SMD_PRI_TYPE_LIGHTING_FLAT 1 // Flat shading (1 normal)
-#define SMD_PRI_TYPE_LIGHTING_SMOOTH 2 // Smooth shading (3 normals per vertex)
+// No shading (no normals)
+#define SMD_PRI_TYPE_LIGHTING_NONE 0
+// Flat shading (1 normal)
+#define SMD_PRI_TYPE_LIGHTING_FLAT 1
+// Smooth shading (3 normals per vectex)
+#define SMD_PRI_TYPE_LIGHTING_SMOOTH 2
 
 #define SMD_PRI_TYPE_COLORING_SOLID 0
 #define SMD_PRI_TYPE_COLORING_GOURAUD 1
 
+// 50% Background + 50% Foreground (50% alpha)
 #define SMD_PRI_TYPE_BLEND_50_ALPHA 0
+// 100% background + 100% foreground (additive)
 #define SMD_PRI_TYPE_BLEND_ADD 1
+// 100% background - 100% foreground (subtractive)
 #define SMD_PRI_TYPE_BLEND_SUB 2
+// 100% background - 25% foreground (subtract 25%)
 #define SMD_PRI_TYPE_BLEND_25_SUB 3
 
 typedef struct {

--- a/libpsn00b/include/smd/smd.h
+++ b/libpsn00b/include/smd/smd.h
@@ -43,6 +43,17 @@ typedef struct {
 	uint8_t len;
 } SMD_PRI_TYPE;
 
+#define SMD_PRI_TYPE_LINE 0
+#define SMD_PRI_TYPE_TRIANGLE 1
+#define SMD_PRI_TYPE_QUAD 2
+
+#define SMD_PRI_TYPE_LIGHTING_NONE 0 // No shading (no normals)
+#define SMD_PRI_TYPE_LIGHTING_FLAT 1 // Flat shading (1 normal)
+#define SMD_PRI_TYPE_LIGHTING_SMOOTH 2 // Smooth shading (3 normals per vertex)
+
+#define SMD_PRI_TYPE_COLORING_SOLID 0
+#define SMD_PRI_TYPE_COLORING_GOURAUD 1
+
 typedef struct {
 	SMD_PRI_TYPE prim_id;
 

--- a/libpsn00b/include/smd/smd.h
+++ b/libpsn00b/include/smd/smd.h
@@ -54,6 +54,11 @@ typedef struct {
 #define SMD_PRI_TYPE_COLORING_SOLID 0
 #define SMD_PRI_TYPE_COLORING_GOURAUD 1
 
+#define SMD_PRI_TYPE_BLEND_50_ALPHA 0
+#define SMD_PRI_TYPE_BLEND_ADD 1
+#define SMD_PRI_TYPE_BLEND_SUB 2
+#define SMD_PRI_TYPE_BLEND_25_SUB 3
+
 typedef struct {
 	SMD_PRI_TYPE prim_id;
 

--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -197,7 +197,7 @@ __attribute__((weak)) void *realloc(void *ptr, size_t size) {
 	// New memory block shorter?
 	if (prev->size >= _size) {
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size - sizeof(BlockHeader);
+		prev->size = _size;
 
 		if (!prev->next)
 			sbrk((ptr - sbrk(0)) + _size);
@@ -212,14 +212,14 @@ __attribute__((weak)) void *realloc(void *ptr, size_t size) {
 			return 0;
 
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size - sizeof(BlockHeader);
+		prev->size = _size;
 		return ptr;
 	}
 
 	// Do we have free memory after it?
 	if (((prev->next)->ptr - ptr) > _size) {
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size - sizeof(BlockHeader);
+		prev->size = _size;
 		return ptr;
 	}
 

--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -85,10 +85,8 @@ static BlockHeader *_find_fit(BlockHeader *head, size_t size) {
 	for (; prev; prev = prev->next) {
 		if (prev->next) {
 			uintptr_t next_bot = (uintptr_t) prev->next;
-			printf("[FindFit] Bottom of next block: %p\n", (void*)next_bot);
 			next_bot          -= (uintptr_t) prev->ptr + prev->size;
-			printf("[FindFit] Offset to free block: %p\n", (void*)prev->ptr + prev->size);
-			printf("[FindFit] Size of free block: %p\n", next_bot);
+
 			if (next_bot >= size)
 				return prev;
 		}

--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -85,8 +85,10 @@ static BlockHeader *_find_fit(BlockHeader *head, size_t size) {
 	for (; prev; prev = prev->next) {
 		if (prev->next) {
 			uintptr_t next_bot = (uintptr_t) prev->next;
+			printf("[FindFit] Bottom of next block: %p\n", (void*)next_bot);
 			next_bot          -= (uintptr_t) prev->ptr + prev->size;
-
+			printf("[FindFit] Offset to free block: %p\n", (void*)prev->ptr + prev->size);
+			printf("[FindFit] Size of free block: %p\n", next_bot);
 			if (next_bot >= size)
 				return prev;
 		}

--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -199,7 +199,7 @@ __attribute__((weak)) void *realloc(void *ptr, size_t size) {
 	// New memory block shorter?
 	if (prev->size >= _size) {
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 
 		if (!prev->next)
 			sbrk((ptr - sbrk(0)) + _size);
@@ -214,14 +214,14 @@ __attribute__((weak)) void *realloc(void *ptr, size_t size) {
 			return 0;
 
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 		return ptr;
 	}
 
 	// Do we have free memory after it?
 	if (((prev->next)->ptr - ptr) > _size) {
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 		return ptr;
 	}
 

--- a/libpsn00b/psxgpu/common.c
+++ b/libpsn00b/psxgpu/common.c
@@ -79,7 +79,7 @@ static void _gpu_dma_handler(void) {
 
 /* GPU reset and system initialization */
 
-void ResetGraph(int mode) {
+void ResetGraph(ResetGraphMode mode) {
 	_queue_head   = 0;
 	_queue_tail   = 0;
 	_queue_length = 0;
@@ -106,7 +106,7 @@ void ResetGraph(int mode) {
 		GPU_GP1 = 0x02000000; // Reset IRQ
 		GPU_GP1 = 0x04000000; // Disable DMA request
 
-		if (mode == 1)
+		if (mode == RESET_GRAPH_DMA_IRQ_COMMAND_BUFFER)
 			return;
 	} else {
 		GPU_GP1 = 0x00000000; // Reset GPU


### PR DESCRIPTION
The PSn00bSDK manual details a lot of the modes/flags used with various structures and functions listing explanations with them and allowed values.

In order to improve the usability of the SDK, this PR introduces enumerations where multiple mode states are present and defines for flag/enablement parameters/fields are used along with brief explanations