### PR TITLE
(OpenBIOS) Change `_bu_init()` ROM offset from `0x55` to `0x70`

### DIFF
--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -85,10 +85,8 @@ static BlockHeader *_find_fit(BlockHeader *head, size_t size) {
 	for (; prev; prev = prev->next) {
 		if (prev->next) {
 			uintptr_t next_bot = (uintptr_t) prev->next;
-			printf("[FindFit] Bottom of next block: %p\n", (void*)next_bot);
 			next_bot          -= (uintptr_t) prev->ptr + prev->size;
-			printf("[FindFit] Offset to free block: %p\n", (void*)prev->ptr + prev->size);
-			printf("[FindFit] Size of free block: %p\n", next_bot);
+
 			if (next_bot >= size)
 				return prev;
 		}

--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -85,8 +85,10 @@ static BlockHeader *_find_fit(BlockHeader *head, size_t size) {
 	for (; prev; prev = prev->next) {
 		if (prev->next) {
 			uintptr_t next_bot = (uintptr_t) prev->next;
+			printf("[FindFit] Bottom of next block: %p\n", (void*)next_bot);
 			next_bot          -= (uintptr_t) prev->ptr + prev->size;
-
+			printf("[FindFit] Offset to free block: %p\n", (void*)prev->ptr + prev->size);
+			printf("[FindFit] Size of free block: %p\n", next_bot);
 			if (next_bot >= size)
 				return prev;
 		}

--- a/libpsn00b/libc/malloc.c
+++ b/libpsn00b/libc/malloc.c
@@ -199,7 +199,7 @@ __attribute__((weak)) void *realloc(void *ptr, size_t size) {
 	// New memory block shorter?
 	if (prev->size >= _size) {
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 
 		if (!prev->next)
 			sbrk((ptr - sbrk(0)) + _size);
@@ -214,14 +214,14 @@ __attribute__((weak)) void *realloc(void *ptr, size_t size) {
 			return 0;
 
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 		return ptr;
 	}
 
 	// Do we have free memory after it?
 	if (((prev->next)->ptr - ptr) > _size) {
 		TrackHeapUsage(size - prev->size);
-		prev->size = _size;
+		prev->size = _size - sizeof(BlockHeader);
 		return ptr;
 	}
 

--- a/libpsn00b/psxapi/drivers.s
+++ b/libpsn00b/psxapi/drivers.s
@@ -14,7 +14,7 @@
 _bu_init:
 	li $t2, 0xa0
 	jr $t2
-	li $t1, 0x55
+	li $t1, 0x70
 
 .section .text._96_init
 .global _96_init

--- a/libpsn00b/psxapi/stubs.json
+++ b/libpsn00b/psxapi/stubs.json
@@ -121,7 +121,7 @@
 	},
 	{
 		"type": "a",
-		"id":   85,
+		"id":   112,
 		"name": "_bu_init",
 		"file": "drivers.s"
 	},


### PR DESCRIPTION
It seems that emulators tend to prefer the `0x70` offset for `_bu_init()` in BIOS implementations. Well at least PCSX's OpenBIOS does (hard to confirm in others, like ePSXe, no$psx, RetroArch/Liberto, etc since most are freeware/closed source).

Given that PCSX-Redux runs pretty much any PS1 game to a T, then it would seem that builds with PsyQ implement `_bu_init()` targetting ROM `0xa0` at offset `0x70` and not `0x55`, given that OpenBIOS only supports `0x70` currently. (I have an [issue](https://github.com/grumpycoders/pcsx-redux/issues/1750) open with PCSX-Redux to change that and support both).

This PR essentially just changes the target offset to match.