### PR TITLE
Mirror link for Lameguy's PlayStation tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ parts of the SDK (mostly graphics); the source code of `n00bdemo` can also be
 found in the same directory. More example programs may be added in the future
 and contributed example programs are welcome.
 
-[Lameguy's PlayStation Programming Tutorial Series](http://lameguy64.net/tutorials/pstutorials)
+[Lameguy's PlayStation Programming Tutorial Series (mirror)](https://www.breck-mckye.com/psnoobsdk-docs/)
 was written with older versions of PSn00bSDK in mind and is outdated at this
 point, but may still be useful as an introduction to the console's hardware and
 the basics of the graphics and controller APIs.


### PR DESCRIPTION
Links the README to a mirror I put up of the original PSNoobSDK tutorial docs

The docs are a straight HTML copy with a header marking them as a mirror - hosted on GH Pages ([repo](https://github.com/jbreckmckye/psnoobsdk-docs))